### PR TITLE
fix issue #1

### DIFF
--- a/{{cookiecutter.role_name}}/test/integration/default.yml
+++ b/{{cookiecutter.role_name}}/test/integration/default.yml
@@ -1,6 +1,6 @@
 ---
 
-# This playbook deploys the {{ cookiecutter.repo_name }} role for testing.
+# This playbook deploys the {{ cookiecutter.role_name }} role for testing.
 
 - hosts: test-kitchen
   user: root


### PR DESCRIPTION
the template failed to generate with the following error message:
Error message: 'dict object' has no attribute 'repo_name'

Signed-off-by: Eric Villard dev@eviweb.fr
